### PR TITLE
feat: add another superuser -- "openedx"

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           $SSH "#! /bin/bash -e
             $TUTOR local do createuser --staff --superuser --password=admin admin admin@openedx.org
+            $TUTOR local do createuser --staff --superuser --password=openedx admin openedx@openedx.org
             $TUTOR local do createuser --password=student student student@openedx.org
           "
       - name: "Provision: Import demo course"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           $SSH "#! /bin/bash -e
             $TUTOR local do createuser --staff --superuser --password=admin admin admin@openedx.org
-            $TUTOR local do createuser --staff --superuser --password=openedx admin openedx@openedx.org
+            $TUTOR local do createuser --staff --superuser --password=openedx openedx openedx@openedx.org
             $TUTOR local do createuser --password=student student student@openedx.org
           "
       - name: "Provision: Import demo course"


### PR DESCRIPTION
This matches PR sandboxes, whose username/password combo is openedx/openedx.

I've left admin/admin in place as well because I don't see any harm in having both accounts, right?