### PR TITLE
build: remove upgrade option

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,10 +13,6 @@ on:
         description: Reset existing platform data?
         type: boolean
         default: false
-      UPGRADE:
-        description: Should run tutor upgrade command?
-        type: boolean
-        default: false
       PRUNE:
         description: Prune Docker system after run?
         type: boolean
@@ -32,7 +28,6 @@ jobs:
       # hack necessary because the inputs are not defined on scheduled calls:
       # https://stackoverflow.com/a/73495922/356528
       RESET: ${{ contains(inputs.RESET, 'true') }}
-      UPGRADE: ${{ contains(inputs.UPGRADE, 'true') }}
       PRUNE: ${{ !contains(inputs.PRUNE, 'false') }}
     steps:
       - name: Configure SSH
@@ -116,9 +111,6 @@ jobs:
             # build other images
             $TUTOR images build mfe forum
           "
-      - name: Run Tutor Upgrade
-        run: $SSH "$TUTOR local upgrade --from=quince"
-        if: ${{ env.UPGRADE == 'true' }}
       - name: Launch
         run: $SSH "$TUTOR local launch --non-interactive"
         if: ${{ env.RESET == 'true' }}


### PR DESCRIPTION
Now that the sandbox is upgraded, we won't need this command anymore. Plus, it is really more meant for jumping from stable release to stable release.  If we run it again, it'll break things (like it did for me)!